### PR TITLE
add full path for the .env file

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,8 @@
 ################################
 # Pull in the configuration
 ################################
-source '.env'
+BASEDIR=$(dirname "$0")
+source "$BASEDIR/.env"
 
 ################################
 # Functions

--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@
 ################################
 # Pull in the configuration
 ################################
-BASEDIR=$(dirname "$0")
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$BASEDIR/.env"
 
 ################################


### PR DESCRIPTION
The .env file resides mainly in the same directory as that of the main.sh file

When running from cron, if you do not cd into the main.sh directory you can get the following error 

```
/opt/sd-serverdiagnostics/main.sh: line 6: .env: No such file or directory
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```

This PR specifies the full path for the `.env` file. 

An alternative way of handling this would be to change the crontab entry to 

```
0 0 * * * cd /opt/sd-serverdiagnostics/ && /bin/bash /opt/sd-serverdiagnostics/main.sh
```